### PR TITLE
Fix messageCallback to return if there is not a callbackId

### DIFF
--- a/dist/keycloak.js
+++ b/dist/keycloak.js
@@ -691,6 +691,9 @@
                     return;
                 }
                 var data = JSON.parse(event.data);
+                if (!data.callbackId) {
+                    return;
+                }
                 var promise = loginIframe.callbackMap[data.callbackId];
                 delete loginIframe.callbackMap[data.callbackId];
 


### PR DESCRIPTION
Keycloak incorrectly assumes that all postMessage events are addressed to it and that the message object contains a callbackId. This causes a script error when any non-Keycloak postMessage events are broadcast which don't contain a callbackId.

First check that there is a callbackId in the message event before accessing the callbackMap.