### PR TITLE
added a package.json file

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "keycloak-js-bower",
+  "version": "1.4.0",
+  "description": "Keycloak Adapter",
+  "main": "dist/keycloak.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/keycloak/keycloak-js-bower"
+  },
+  "author": "Keycloak",
+  "license": "Apache-2.0",
+  "homepage": "https://github.com/keycloak/keycloak-js-bower",
+  "keywords": [
+    "keycloak",
+    "sso",
+    "oauth",
+    "oauth2",
+    "authentication"
+  ]
+}


### PR DESCRIPTION
Create a package.json file so it is possible to consume the keycloak adapter not only with bower but also with npm. This makes it easier in e.g. projects which are using webpack. 
additionally most libraries are available on bower as well as on npm. 