### PR TITLE
Fix parameter encoding

### DIFF
--- a/dist/keycloak.js
+++ b/dist/keycloak.js
@@ -153,19 +153,19 @@
                 + '&response_type=code';
 
             if (options && options.prompt) {
-                url += '&prompt=' + options.prompt;
+                url += '&prompt=' + encodeURIComponent(options.prompt);
             }
 
             if (options && options.loginHint) {
-                url += '&login_hint=' + options.loginHint;
+                url += '&login_hint=' + encodeURIComponent(options.loginHint);
             }
 
             if (options && options.idpHint) {
-                url += '&kc_idp_hint=' + options.idpHint;
+                url += '&kc_idp_hint=' + encodeURIComponent(options.idpHint);
             }
 
             if (options && options.scope) {
-                url += '&scope=' + options.scope;
+                url += '&scope=' + encodeURIComponent(options.scope);
             }
 
             return url;


### PR DESCRIPTION
This PR fixes the encoding for the optional parameters.

I've noticed an issue with the parameter encoding when passing an email address that contains a plus (e.g. 'example+test@example.com') as `loginHint`. It'll populate the form field incorrectly (e.g. 'example test@example.com'), because the plus is interpreted as a space.

