### PR TITLE
Add an option to always force the load of default adapter

### DIFF
--- a/dist/keycloak.js
+++ b/dist/keycloak.js
@@ -33,9 +33,12 @@
         };
 
         kc.init = function (initOptions) {
-            kc.authenticated = false;
-
-            if (window.Cordova) {
+            var forceDefaultAdapter = false;
+            if (initOptions && typeof initOptions.forceDefaultAdapter === 'boolean') {
+                forceDefaultAdapter = initOptions.forceDefaultAdapter;
+            }
+ 
+            if (window.Cordova && forceDefaultAdapter === false) {
                 adapter = loadAdapter('cordova');
             } else {
                 adapter = loadAdapter();


### PR DESCRIPTION
In some cases, we can use a remote app URL as cordova  content. 
That mean we are loading an URI instead of the local index.html file to run to our app, and, we don't need to use InAppBrowser plugin anymore neither open a new window.
We can use the same behaviour than we have on regular desktop except that we are using cordova web view.

It is compatible with WKWebView and the old UIWebView and also with Android web view and Crosswalk WebView.