### PR TITLE
Fix broken link to Keycloak documentation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Keycloak JavaScript Adapter
 ===========================
 
-JavaScript adapter for [Keycloak](http://www.keycloak.org/). For documentation see our [Securing Clients and Applications Guide](https://keycloak.gitbooks.io/securing-client-applications-guide/content/topics/oidc/javascript-adapter.html).
+JavaScript adapter for [Keycloak](http://www.keycloak.org/). For documentation see our [Securing Clients and Applications Guide](https://keycloak.gitbooks.io/documentation/securing_apps/topics/oidc/javascript-adapter.html).
 
 ## Issues
 


### PR DESCRIPTION
The link to the documentation in the README `https://www.gitbook.com/read/book/keycloak/securing-client-applications-guide/topics/oidc/javascript-adapter.html` results in a 404. I propose changing this to `https://keycloak.gitbooks.io/documentation/securing_apps/topics/oidc/javascript-adapter.html`.

