### PR TITLE
promise was never resolved

### DIFF
--- a/dist/keycloak.js
+++ b/dist/keycloak.js
@@ -874,10 +874,8 @@
                 if (loginIframe.callbackList.length == 1) {
                     loginIframe.iframe.contentWindow.postMessage(msg, origin);
                 }
-                promise.setSuccess();
-            } else {
-                promise.setSuccess();
             }
+            promise.setSuccess();
 
             return promise.promise;
         }

--- a/dist/keycloak.js
+++ b/dist/keycloak.js
@@ -874,6 +874,7 @@
                 if (loginIframe.callbackList.length == 1) {
                     loginIframe.iframe.contentWindow.postMessage(msg, origin);
                 }
+                promise.setSuccess();
             } else {
                 promise.setSuccess();
             }


### PR DESCRIPTION
Promise was never resolved when the `loginIframe` object had an `iframe` and an `iframeOrigin` fields.

Also, we could argue the use of a promise in this function as it appears to be synchronous code only?