### PR TITLE
Updates link to point to new docs (keycloak.org)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Keycloak JavaScript Adapter
 ===========================
 
-JavaScript adapter for [Keycloak](http://www.keycloak.org/). For documentation see our [Securing Clients and Applications Guide](https://keycloak.gitbooks.io/documentation/securing_apps/topics/oidc/javascript-adapter.html).
+JavaScript adapter for [Keycloak](http://www.keycloak.org/). For documentation see our [Securing Clients and Applications Guide](http://www.keycloak.org/docs/3.3/securing_apps/topics/oidc/javascript-adapter.html).
 
 ## Issues
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Keycloak JavaScript Adapter
 ===========================
 
-JavaScript adapter for [Keycloak](http://www.keycloak.org/). For documentation see our [Securing Clients and Applications Guide](http://www.keycloak.org/docs/3.3/securing_apps/topics/oidc/javascript-adapter.html).
+JavaScript adapter for [Keycloak](http://www.keycloak.org/). For documentation see our [Securing Clients and Applications Guide](http://www.keycloak.org/docs/latest/securing_apps/topics/oidc/javascript-adapter.html).
 
 ## Issues
 


### PR DESCRIPTION
I went to lookup docs for the javascript adapter and noticed they have moved to keycloak.org