### PR TITLE
Use cordova adapter for IOS

### DIFF
--- a/dist/keycloak.js
+++ b/dist/keycloak.js
@@ -50,7 +50,7 @@
             } else if (initOptions && initOptions.adapter === 'default') {
                 adapter = loadAdapter();
             } else {
-                if (window.Cordova) {
+                if (window.Cordova || window.cordova) {
                     adapter = loadAdapter('cordova');
                 } else {
                     adapter = loadAdapter();


### PR DESCRIPTION
When running keycloak library as part of cordova application on IOS wrong adapter is used:

![screen shot 2017-09-27 at 2 43 52 pm](https://user-images.githubusercontent.com/981838/30916882-68607200-a392-11e7-8249-3233e805fbe9.png)

Looks like most recent versions of cordova are mounting on window.cordova. 